### PR TITLE
Moved use statements to separate file to fix compatibility with PrestaShop 1.6

### DIFF
--- a/getresponse.php
+++ b/getresponse.php
@@ -8,12 +8,12 @@
  *  International Registered Trademark & Property of PrestaShop SA
  */
 
-use GrShareCode\Api\Exception\GetresponseApiException;
-use GrShareCode\Validation\Assert\InvalidArgumentException;
-
 if (!defined('_PS_VERSION_')) {
     exit;
 }
+
+// Move all "use" statements in this file:
+include_once _PS_MODULE_DIR_ . '/getresponse/vendor.php';
 
 include_once _PS_MODULE_DIR_ . '/getresponse/vendor/autoload.php';
 include_once _PS_MODULE_DIR_ . '/getresponse/classes/GrApiException.php';

--- a/vendor.php
+++ b/vendor.php
@@ -1,0 +1,5 @@
+<?php
+
+// Live here because they cannot be in the main module file
+use GrShareCode\Api\Exception\GetresponseApiException;
+use GrShareCode\Validation\Assert\InvalidArgumentException;


### PR DESCRIPTION
Since version 16.3.2 of this module, the compatibility with PrestaShop 1.6 is broken, even though `ps_versions_compliancy` is still includes 1.6.

The problem is that "use" statements cannot be used in the main module file since it gets eval'd by the Module class. This solution is a bit hacky but it works.